### PR TITLE
Limit width of containers

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -55,6 +55,7 @@ nav a, footer a {
 
 section {
   width: 80%;
+  max-width: 60em;
   margin: 40px auto;
   border-bottom: 5px dotted black;
   padding-bottom: 40px;


### PR DESCRIPTION
Instead of 80%, add a hard limit of 60em to prevent lines of text to be
way too long to be able to read them comfortably.